### PR TITLE
Added sstream include to avoid implicit instantiation compile error

### DIFF
--- a/src/binacpp.h
+++ b/src/binacpp.h
@@ -17,6 +17,7 @@
 #include <stdarg.h>
 
 #include <iostream>
+#include <sstream>
 #include <string>
 #include <map>
 #include <vector>


### PR DESCRIPTION
Received this error during compilation:
```
In file included from /Users/alexander/Development/External/binacpp/src/binacpp.cpp:14:
/Users/alexander/Development/External/binacpp/src/binacpp.h:52:23: error: implicit instantiation of undefined template
      'std::__1::basic_ostringstream<char, std::__1::char_traits<char>, std::__1::allocator<char> >'
                        std::ostringstream out;
```
Caused by the usage of `std::ostringstream` without inclusion of `sstream` standard lib.