### PR TITLE
libcurl optimizations

### DIFF
--- a/src/binacpp.h
+++ b/src/binacpp.h
@@ -37,7 +37,7 @@ class BinaCPP {
 
 	static string api_key;
 	static string secret_key;
-
+	static CURL* curl;
 
 	
 
@@ -50,6 +50,7 @@ class BinaCPP {
 		static size_t curl_cb( void *content, size_t size, size_t nmemb, string *buffer ) ;
 		
 		static void init( string &api_key, string &secret_key);
+		static void cleanup();
 
 
 		// Public API

--- a/src/binacpp_utils.h
+++ b/src/binacpp_utils.h
@@ -23,26 +23,6 @@ string b2a_hex( char *byte_arr, int n );
 time_t get_current_epoch();
 unsigned long get_current_ms_epoch();
 
-//--------------------
-template <class T>
-inline string to_string (const T& t)
-{
-    stringstream ss;
-    ss << t;
-    return ss.str();
-}
-
-
-static std::string to_string(double val)
-{
-	std::ostringstream out;
-	out.precision(8);
-	out.setf(std::ios_base::fixed);
-	out << val;
-	return out.str();
-}
-
-
 
 //--------------------
 inline bool file_exists (const std::string& name) {


### PR DESCRIPTION
Typical REST response time on a machine in California is cut down from ~600-800ms to ~100-200ms by initializing the curl object only in the beginning of the program.