### PR TITLE
Fixed a bug that caused cURL to fail when calling multiple times

### DIFF
--- a/src/binacpp.cpp
+++ b/src/binacpp.cpp
@@ -1857,6 +1857,7 @@ BinaCPP::curl_api_with_header( string &url, string &str_result, vector <string> 
 			BinaCPP_logger::write_log( "<BinaCPP::curl_api> curl_easy_perform() failed: %s" , curl_easy_strerror(res) ) ;
 		} 	
 
+		curl_easy_reset(BinaCPP::curl);
 	}
 
 	BinaCPP_logger::write_log( "<BinaCPP::curl_api> done" ) ;


### PR DESCRIPTION
When calling the curl_api multiple times,
calls after the first call would either fail or return an "invalid signature" HTTP response. (https://github.com/binance-exchange/binacpp/issues/33)

Added calling curl_easy_reset() after curl_api().